### PR TITLE
Support for uneven gridded data and nonperiodic boundary conditions for velocity structure functions

### DIFF
--- a/oceans_sf/advection_velocity.py
+++ b/oceans_sf/advection_velocity.py
@@ -21,6 +21,7 @@ def advection_velocity(
     """
     u = par_u
     v = par_v
+    b = boundary
 
     # if boundary == "Periodic":
     #     sep = range(int(len(u) / 2))
@@ -64,7 +65,7 @@ def advection_velocity(
             "You must select at least one of the sampling options: meridional, zonal, or isotropic."
         )
 
-    adv_E, adv_N = calculate_velocity_advection(u, v, x, y)
+    adv_E, adv_N = calculate_velocity_advection(u, v, x, y, b)
 
     if meridional == True:
         # if boundary == "Periodic":
@@ -77,11 +78,20 @@ def advection_velocity(
             # yroll = np.roll(y, i, axis=0)
             xd[i] = (np.abs(xroll - x))[len(sep_m)]
             # yd[i] = (np.abs(yroll - y))[len(sep)]
-
-            SF_m[i] = np.nanmean(
-                (np.roll(adv_E, i, axis=0) - adv_E) * (np.roll(u, i, axis=0) - u)
-                + (np.roll(adv_N, i, axis=0) - adv_N) * (np.roll(v, i, axis=0) - v)
-            )
+            if boundary == "Periodic":
+                SF_m[i] = np.nanmean(
+                    (np.roll(adv_E, i, axis=0) - adv_E) * (np.roll(u, i, axis=0) - u)
+                    + (np.roll(adv_N, i, axis=0) - adv_N) * (np.roll(v, i, axis=0) - v)
+                )
+            else:
+                SF_m[i] = np.nanmean(
+                    (
+                        (np.roll(adv_E, i, axis=0) - adv_E)
+                        * (np.roll(u[1:-1, 1:-1], i, axis=0) - u[1:-1, 1:-1])
+                        + (np.roll(adv_N, i, axis=0) - adv_N)
+                        * (np.roll(v[1:-1, 1:-1], i, axis=0) - v[1:-1, 1:-1])
+                    )[i:]
+                )
 
     if zonal == True:
         # if boundary == "Periodic":
@@ -96,10 +106,22 @@ def advection_velocity(
             yd[i] = (np.abs(yroll - y))[len(sep_z)]
 
             if zonal == True:
-                SF_z[i] = np.nanmean(
-                    (np.roll(adv_E, i, axis=1) - adv_E) * (np.roll(u, i, axis=1) - u)
-                    + (np.roll(adv_N, i, axis=1) - adv_N) * (np.roll(v, i, axis=1) - v)
-                )
+                if boundary == "Periodic":
+                    SF_z[i] = np.nanmean(
+                        (np.roll(adv_E, i, axis=1) - adv_E)
+                        * (np.roll(u, i, axis=1) - u)
+                        + (np.roll(adv_N, i, axis=1) - adv_N)
+                        * (np.roll(v, i, axis=1) - v)
+                    )
+                else:
+                    SF_z[i] = np.nanmean(
+                        (
+                            (np.roll(adv_E, i, axis=1) - adv_E)
+                            * (np.roll(u[1:-1, 1:-1], i, axis=1) - u[1:-1, 1:-1])
+                            + (np.roll(adv_N, i, axis=1) - adv_N)
+                            * (np.roll(v[1:-1, 1:-1], i, axis=1) - v[1:-1, 1:-1])
+                        )[:, i:]
+                    )
 
                 if even == False:
                     d_uneven[i] = gd.geodesic((xroll[i], yroll[i]), (x[i], y[i])).km

--- a/oceans_sf/advection_velocity.py
+++ b/oceans_sf/advection_velocity.py
@@ -49,26 +49,43 @@ def advection_velocity(
 
     adv_E, adv_N = calculate_velocity_advection(u, v, x, y)
 
-    for i in range(len(sep)):
-        xroll = np.roll(x, i, axis=0)
-        yroll = np.roll(y, i, axis=0)
-        xd[i] = (np.abs(xroll - x))[len(sep)]
-        yd[i] = (np.abs(yroll - y))[len(sep)]
+    if meridional == True:
+        if boundary == "Periodic":
+            sep = range(int(len(y) / 2))
+        else:
+            sep = range(int(len(y)) - 1)
 
-        if meridional == True:
+        for i in range(len(sep)):
+            xroll = np.roll(x, i, axis=0)
+            yroll = np.roll(y, i, axis=0)
+            # xd[i] = (np.abs(xroll - x))[len(sep)]
+            yd[i] = (np.abs(yroll - y))[len(sep)]
+
             SF_m[i] = np.nanmean(
                 (np.roll(adv_E, i, axis=0) - adv_E) * (np.roll(u, i, axis=0) - u)
                 + (np.roll(adv_N, i, axis=0) - adv_N) * (np.roll(v, i, axis=0) - v)
             )
 
-        if zonal == True:
-            SF_z[i] = np.nanmean(
-                (np.roll(adv_E, i, axis=1) - adv_E) * (np.roll(u, i, axis=1) - u)
-                + (np.roll(adv_N, i, axis=1) - adv_N) * (np.roll(v, i, axis=1) - v)
-            )
+    if zonal == True:
+        if boundary == "Periodic":
+            sep = range(int(len(x) / 2))
+        else:
+            sep = range(int(len(x)) - 1)
 
-            if even == False:
-                d_uneven[i] = gd.geodesic((xroll[i], yroll[i]), (x[i], y[i])).km
+        for i in range(len(sep)):
+            xroll = np.roll(x, i, axis=0)
+            yroll = np.roll(y, i, axis=0)
+            xd[i] = (np.abs(xroll - x))[len(sep)]
+            # yd[i] = (np.abs(yroll - y))[len(sep)]
+
+            if zonal == True:
+                SF_z[i] = np.nanmean(
+                    (np.roll(adv_E, i, axis=1) - adv_E) * (np.roll(u, i, axis=1) - u)
+                    + (np.roll(adv_N, i, axis=1) - adv_N) * (np.roll(v, i, axis=1) - v)
+                )
+
+                if even == False:
+                    d_uneven[i] = gd.geodesic((xroll[i], yroll[i]), (x[i], y[i])).km
 
     if even == False:
         tmp = {"d": d_uneven, "SF_z": SF_z}
@@ -78,6 +95,11 @@ def advection_velocity(
         SF_z_uneven = means["SF_z"].values
 
     if isotropic == True:
+        if boundary == "Periodic":
+            sep = range(int(len(x) / 2))
+        else:
+            sep = range(int(len(x)) - 1)
+
         sep_combinations = np.array(np.meshgrid(sep, sep)).T.reshape(-1, 2)
         tmp = np.zeros(np.shape(sep_combinations))
         for idx, xy in enumerate(sep_combinations):

--- a/oceans_sf/advection_velocity.py
+++ b/oceans_sf/advection_velocity.py
@@ -22,25 +22,42 @@ def advection_velocity(
     u = par_u
     v = par_v
 
-    if boundary == "Periodic":
-        sep = range(int(len(u) / 2))
-    else:
-        sep = range(int(len(u)) - 1)
+    # if boundary == "Periodic":
+    #     sep = range(int(len(u) / 2))
+    # else:
+    #     sep = range(int(len(u)) - 1)
 
-    xd = np.zeros(np.shape(sep))
-    yd = np.zeros(np.shape(sep))
+    # xd = np.zeros(np.shape(sep))
+    # yd = np.zeros(np.shape(sep))
 
-    if even == False:
-        d_uneven = np.zeros(np.shape(sep))
+    # if even == False:
+    #     d_uneven = np.zeros(np.shape(sep))
 
     if zonal == True:
-        SF_z = np.zeros(np.shape(sep))
+        if boundary == "Periodic":
+            sep_z = range(int(len(y) / 2))
+        else:
+            sep_z = range(int(len(y) - 1))
+
+        yd = np.zeros(np.shape(sep_z))
+
+        SF_z = np.zeros(np.shape(sep_z))
+
+        if even == False:
+            d_uneven = np.zeros(np.shape(sep_z))
 
     if meridional == True:
-        SF_m = np.zeros(np.shape(sep))
+        if boundary == "Periodic":
+            sep_m = range(int(len(x) / 2))
+        else:
+            sep_m = range(int(len(x) - 1))
 
-    if isotropic == True:
-        SF_iso = np.zeros(np.shape(sep))
+        xd = np.zeros(np.shape(sep_m))
+
+        SF_m = np.zeros(np.shape(sep_m))
+
+    # if isotropic == True:
+    #     SF_iso = np.zeros(np.shape(sep))
 
     if zonal == False and meridional == False and isotropic == False:
         raise SystemExit(
@@ -50,16 +67,16 @@ def advection_velocity(
     adv_E, adv_N = calculate_velocity_advection(u, v, x, y)
 
     if meridional == True:
-        if boundary == "Periodic":
-            sep = range(int(len(y) / 2))
-        else:
-            sep = range(int(len(y)) - 1)
+        # if boundary == "Periodic":
+        #     sep = range(int(len(y) / 2))
+        # else:
+        #     sep = range(int(len(y)) - 1)
 
-        for i in range(len(sep)):
+        for i in range(len(sep_m)):
             xroll = np.roll(x, i, axis=0)
-            yroll = np.roll(y, i, axis=0)
-            # xd[i] = (np.abs(xroll - x))[len(sep)]
-            yd[i] = (np.abs(yroll - y))[len(sep)]
+            # yroll = np.roll(y, i, axis=0)
+            xd[i] = (np.abs(xroll - x))[len(sep_m)]
+            # yd[i] = (np.abs(yroll - y))[len(sep)]
 
             SF_m[i] = np.nanmean(
                 (np.roll(adv_E, i, axis=0) - adv_E) * (np.roll(u, i, axis=0) - u)
@@ -67,16 +84,16 @@ def advection_velocity(
             )
 
     if zonal == True:
-        if boundary == "Periodic":
-            sep = range(int(len(x) / 2))
-        else:
-            sep = range(int(len(x)) - 1)
+        # if boundary == "Periodic":
+        #     sep = range(int(len(x) / 2))
+        # else:
+        #     sep = range(int(len(x)) - 1)
 
-        for i in range(len(sep)):
+        for i in range(len(sep_z)):
             xroll = np.roll(x, i, axis=0)
             yroll = np.roll(y, i, axis=0)
-            xd[i] = (np.abs(xroll - x))[len(sep)]
-            # yd[i] = (np.abs(yroll - y))[len(sep)]
+            # xd[i] = (np.abs(xroll - x))[len(sep)]
+            yd[i] = (np.abs(yroll - y))[len(sep_z)]
 
             if zonal == True:
                 SF_z[i] = np.nanmean(

--- a/oceans_sf/advection_velocity.py
+++ b/oceans_sf/advection_velocity.py
@@ -62,17 +62,13 @@ def advection_velocity(
             )
 
         if zonal == True:
-            if even == True:
-                SF_z[i] = np.nanmean(
-                    (np.roll(adv_E, i, axis=1) - adv_E) * (np.roll(u, i, axis=1) - u)
-                    + (np.roll(adv_N, i, axis=1) - adv_N) * (np.roll(v, i, axis=1) - v)
-                )
+            SF_z[i] = np.nanmean(
+                (np.roll(adv_E, i, axis=1) - adv_E) * (np.roll(u, i, axis=1) - u)
+                + (np.roll(adv_N, i, axis=1) - adv_N) * (np.roll(v, i, axis=1) - v)
+            )
+
             if even == False:
                 d_uneven[i] = gd.geodesic((xroll[i], yroll[i]), (x[i], y[i])).km
-                SF_z[i] = np.nanmean(
-                    (np.roll(adv_E, i, axis=1) - adv_E) * (np.roll(u, i, axis=1) - u)
-                    + (np.roll(adv_N, i, axis=1) - adv_N) * (np.roll(v, i, axis=1) - v)
-                )
 
     if even == False:
         tmp = {"d": d_uneven, "SF_z": SF_z}

--- a/oceans_sf/advection_velocity.py
+++ b/oceans_sf/advection_velocity.py
@@ -75,7 +75,7 @@ def advection_velocity(
         df = pd.DataFrame(tmp)
         means = df.groupby(pd.qcut(df["d"], q=nbins)).mean()
         d_uneven = means["d"].values
-        SF_z = means["SF_z"].values
+        SF_z_uneven = means["SF_z"].values
 
     if isotropic == True:
         sep_combinations = np.array(np.meshgrid(sep, sep)).T.reshape(-1, 2)
@@ -104,6 +104,11 @@ def advection_velocity(
         SF_z
     except NameError:
         SF_z = None
+
+    try:
+        SF_z_uneven
+    except NameError:
+        SF_z_uneven = None
 
     try:
         SF_m
@@ -137,6 +142,7 @@ def advection_velocity(
 
     data = {
         "SF_zonal": SF_z,
+        "SF_zonal_uneven": SF_z_uneven,
         "SF_meridional": SF_m,
         "SF_isotropic": SF_iso,
         "x-diffs": xd,

--- a/oceans_sf/calculate_velocity_advection.py
+++ b/oceans_sf/calculate_velocity_advection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def calculate_velocity_advection(par_u, par_v, x, y):
+def calculate_velocity_advection(par_u, par_v, x, y, boundary="Periodic"):
     """
     Add docstring
     """
@@ -21,12 +21,26 @@ def calculate_velocity_advection(par_u, par_v, x, y):
     u_jp1 = np.roll(u, -1, axis=0)
     u_jm1 = np.roll(u, 1, axis=0)
 
-    dudx = (u_ip1 - u_im1) / (2 * dx)
-    dvdx = (v_ip1 - v_im1) / (2 * dx)
-    dudy = (u_jp1 - u_jm1) / (2 * dy)
-    dvdy = (v_jp1 - v_jm1) / (2 * dy)
+    if boundary == "Periodic":
+        dudx = (u_ip1 - u_im1) / (2 * dx)
+        dvdx = (v_ip1 - v_im1) / (2 * dx)
+        dudy = (u_jp1 - u_jm1) / (2 * dy)
+        dvdy = (v_jp1 - v_jm1) / (2 * dy)
 
-    eastward_advection = u * dudx + v * dudy
-    northward_advection = u * dvdx + v * dvdy
+        eastward_advection = u * dudx + v * dudy
+        northward_advection = u * dvdx + v * dvdy
+
+    else:
+        # dudx = (u_ip1[:, :-1] - u_im1[:, 1:]) / (2 * dx)
+        # dvdx = (v_ip1[:, :-1] - v_im1[:, 1:]) / (2 * dx)
+        # dudy = (u_jp1[:-1] - u_jm1[1:]) / (2 * dy)
+        # dvdy = (v_jp1[:-1] - v_jm1[1:]) / (2 * dy)
+        dudx = (u_ip1 - u_im1) / (2 * dx)
+        dvdx = (v_ip1 - v_im1) / (2 * dx)
+        dudy = (u_jp1 - u_jm1) / (2 * dy)
+        dvdy = (v_jp1 - v_jm1) / (2 * dy)
+
+        eastward_advection = (u * dudx + v * dudy)[1:-1, 1:-1]
+        northward_advection = (u * dvdx + v * dvdy)[1:-1, 1:-1]
 
     return (eastward_advection, northward_advection)

--- a/oceans_sf/traditional_velocity.py
+++ b/oceans_sf/traditional_velocity.py
@@ -14,9 +14,9 @@ def traditional_velocity(
     v = par_v
 
     if boundary == "Periodic":
-        sep = range(int(len(u) / 2))
+        sep = range(int(len(y) / 2))
     else:
-        sep = range(int(len(u)))
+        sep = range(int(len(y) - 1))
 
     SF_z = np.zeros(np.shape(sep))
     SF_m = np.zeros(np.shape(sep))
@@ -34,10 +34,14 @@ def traditional_velocity(
 
         dm = np.roll(v, i, axis=0) - v
         dm3 = dm**order
+        if boundary == None:
+            dm3 = dm[i:] ** order
         SF_m[i] = np.nanmean(dm3)
 
         dz = np.roll(u, i, axis=1) - u
         dz3 = dz**order
+        if boundary == None:
+            dz3 = dz[:, i:] ** order
         SF_z[i] = np.nanmean(dz3)
 
         if even == False:

--- a/oceans_sf/traditional_velocity.py
+++ b/oceans_sf/traditional_velocity.py
@@ -1,7 +1,11 @@
 import numpy as np
+import pandas as pd
+import geopy.distance as gd
 
 
-def traditional_velocity(par_u, par_v, x, y, boundary="Periodic", order=3):
+def traditional_velocity(
+    par_u, par_v, x, y, boundary="Periodic", order=3, even="True", nbins=10
+):
     """
     Add docstring
     """
@@ -19,15 +23,44 @@ def traditional_velocity(par_u, par_v, x, y, boundary="Periodic", order=3):
     xd = np.zeros(np.shape(sep))
     yd = np.zeros(np.shape(sep))
 
-    for i in range(len(sep)):
-        xd[i] = (np.abs(np.roll(x, i, axis=0) - x))[len(sep)]
-        yd[i] = (np.abs(np.roll(y, i, axis=0) - y))[len(sep)]
+    if even == False:
+        d_uneven = np.zeros(np.shape(sep))
 
-        dz = np.roll(u, i, axis=1) - u
+    for i in range(len(sep)):
+        xroll = np.roll(x, i, axis=0)
+        yroll = np.roll(y, i, axis=0)
+        xd[i] = (np.abs(xroll - x))[len(sep)]
+        yd[i] = (np.abs(yroll - y))[len(sep)]
+
         dm = np.roll(v, i, axis=0) - v
-        dz3 = dz**order
         dm3 = dm**order
-        SF_z[i] = np.nanmean(dz3)
         SF_m[i] = np.nanmean(dm3)
 
-    return (SF_z, SF_m, xd, yd)
+        dz = np.roll(u, i, axis=1) - u
+        dz3 = dz**order
+        SF_z[i] = np.nanmean(dz3)
+
+        if even == False:
+            d_uneven[i] = gd.geodesic((xroll[i], yroll[i]), (x[i], y[i])).km
+
+    if even == False:
+        tmp = {"d": d_uneven, "SF_z": SF_z}
+        df = pd.DataFrame(tmp)
+        means = df.groupby(pd.qcut(df["d"], q=nbins)).mean()
+        d_uneven = means["d"].values
+        SF_z = means["SF_z"].values
+
+    try:
+        d_uneven
+    except NameError:
+        d_uneven = None
+
+    data = {
+        "SF_zonal": SF_z,
+        "SF_meridional": SF_m,
+        "x-diffs": xd,
+        "y-diffs": yd,
+        "x-diffs_uneven": d_uneven,
+    }
+
+    return data

--- a/oceans_sf/traditional_velocity.py
+++ b/oceans_sf/traditional_velocity.py
@@ -48,15 +48,21 @@ def traditional_velocity(
         df = pd.DataFrame(tmp)
         means = df.groupby(pd.qcut(df["d"], q=nbins)).mean()
         d_uneven = means["d"].values
-        SF_z = means["SF_z"].values
+        SF_z_uneven = means["SF_z"].values
 
     try:
         d_uneven
     except NameError:
         d_uneven = None
 
+    try:
+        SF_z_uneven
+    except NameError:
+        SF_z_uneven = None
+
     data = {
         "SF_zonal": SF_z,
+        "SF_zonal_uneven": SF_z_uneven,
         "SF_meridional": SF_m,
         "x-diffs": xd,
         "y-diffs": yd,


### PR DESCRIPTION
## Summary

1. User can now provide **uneven gridded data** when computing structure functions. This can include data such as satellite swaths and ship tracks, or slices of uniformly gridded data. 
2. **Nonperiodic boundary conditions** are now supported.

## Checklist
- [x] Traditional velocity SFs can be computed from nonperiodic boundary conditions
- [x] Advective velocity SFs can be computed from nonperiodic boundary conditions

## Future work
* Support uneven data without grid structure
* Support nonperiodic boundary conditions for scalar advection SF
* Support nonperiodic boundary conditions for scalar traditional SF
* Support uneven gridded data for scalar advection SF
* Support uneven gridded data for scalar traditional SF