### PR TITLE
Zonal/meridional notation to x/y

### DIFF
--- a/oceans_sf/calculate_advection.py
+++ b/oceans_sf/calculate_advection.py
@@ -13,7 +13,7 @@ def calculate_advection(  # noqa: D417
 ):
     """
     Calculate the advection for a velocity field or scalar field. The velocity field
-    will return advection components in the eastward and northward directions.
+    will return advection components in the x and y directions.
     The scalar field will return the scalar advection. Defaults to advection for
     velocity field. If the velocity advection is skipped or a scalar field is not
     provided, the relevant dictionary key will return None.
@@ -40,9 +40,8 @@ def calculate_advection(  # noqa: D417
     Returns
     -------
         tuple or ndarray:
-            A tuple of advection components (eastward_advection,
-            northward_advection) if scalar is not provided, otherwise returns an ndarray
-            of scalar advection.
+            A tuple of advection components (x and y) if scalar is not provided, 
+            otherwise returns an ndarray of scalar advection.
     """
     if grid_type == "uniform":
         dx = np.abs(x[0] - x[1])
@@ -67,8 +66,8 @@ def calculate_advection(  # noqa: D417
     if scalar is not None:
         advection = u * dsdx + v * dsdy
     else:
-        eastward_advection = u * dudx + v * dudy
-        northward_advection = u * dvdx + v * dvdy
-        advection = (eastward_advection, northward_advection)
+        x_advection = u * dudx + v * dudy
+        y_advection = u * dvdx + v * dvdy
+        advection = (x_advection, y_advection)
 
     return advection

--- a/oceans_sf/calculate_advection.py
+++ b/oceans_sf/calculate_advection.py
@@ -40,7 +40,7 @@ def calculate_advection(  # noqa: D417
     Returns
     -------
         tuple or ndarray:
-            A tuple of advection components (x and y) if scalar is not provided, 
+            A tuple of advection components (x and y) if scalar is not provided,
             otherwise returns an ndarray of scalar advection.
     """
     if grid_type == "uniform":

--- a/oceans_sf/calculate_structure_function.py
+++ b/oceans_sf/calculate_structure_function.py
@@ -6,10 +6,10 @@ from .shift_array2d import shift_array2d
 def calculate_structure_function(  # noqa: D417, C901
     u,
     v,
-    adv_e,
-    adv_n,
-    down,
-    right,
+    adv_x,
+    adv_y,
+    shift_x,
+    shift_y,
     skip_velocity_sf=False,
     scalar=None,
     adv_scalar=None,
@@ -26,18 +26,14 @@ def calculate_structure_function(  # noqa: D417, C901
             Array of u velocities.
         v: ndarray
             Array of v velocities.
-        adv_e: ndarray
-            Array of eastward advection values.
-        adv_n: ndarray
-            Array of northward advection values.
-        down: int
-            Shift amount for downward shift. For periodic data should be less than half
-            the column length and less than the column length for other boundary
-            conditions.
-        right: int
-            Shift amount for rightward shift. For periodic data should be less than
-            half the row length and less than the row length for other boundary
-            conditions.
+        adv_x: ndarray
+            Array of x-dir advection values.
+        adv_y: ndarray
+            Array of y-dir advection values.
+        shift_x: int
+            Shift amount for x shift.
+        shift_y: int
+            Shift amount for y shift.
         skip_velocity_sf: bool, optional
             Whether to skip velocity-based structure function calculation.
             Defaults to False.
@@ -60,28 +56,26 @@ def calculate_structure_function(  # noqa: D417, C901
             A dictionary containing the advection velocity structure functions and
             scalar structure functions (if applicable).
             The dictionary has the following keys:
-                'SF_velocity_right': The advection velocity structure function in the
-                right direction.
-                'SF_velocity_down': The advection velocity structure function in the
-                down direction.
-                'SF_trad_velocity_right': The traditional velocity structure function in
-                the right direction (if traditional_order > 0).
-                'SF_trad_velocity_down': The traditional velocity structure function in
-                the down direction (if traditional_order > 0).
-                'SF_scalar_right': The scalar structure function in the right direction
-                (if scalar is provided).
-                'SF_scalar_down': The scalar structure function in the down direction
-                (if scalar is provided).
-                'SF_trad_scalar_right': The traditional scalar structure function in the
-                right direction (if scalar is provided and traditional_order > 0).
-                'SF_trad_scalar_down': The traditional scalar structure function in the
-                down direction (if scalar is provided and traditional_order > 0).
+                'SF_velocity_x': The advection velocity structure function in the
+                x direction.
+                'SF_velocity_y': The advection velocity structure function in the
+                y direction.
+                'SF_scalar_x': The scalar structure function in the x direction.
+                'SF_scalar_y': The scalar structure function in the y direction.
+                'SF_LL_x': The traditional structure function LL in the x direction.
+                'SF_LL_y': The traditional structure function LL in the y direction.
+                'SF_LLL_x': The traditional structure function LLL in the x direction.
+                'SF_LLL_y': The traditional structure function LLL in the y direction.
+                'SF_LTT_x': The traditional structure function LTT in the x direction.
+                'SF_LTT_y': The traditional structure function LTT in the y direction.
+                'SF_LSS_x': The traditional structure function LSS in the x direction.
+                'SF_LSS_y': The traditional structure function LSS in the y direction.
     """
     inputs = {
         "u": u,
         "v": v,
-        "adv_e": adv_e,
-        "adv_n": adv_n,
+        "adv_x": adv_x,
+        "adv_y": adv_y,
         "scalar": scalar,
         "adv_scalar": adv_scalar,
     }
@@ -91,8 +85,8 @@ def calculate_structure_function(  # noqa: D417, C901
             {
                 "u": None,
                 "v": None,
-                "adv_e": None,
-                "adv_n": None,
+                "adv_x": None,
+                "adv_y": None,
             }
         )
 
@@ -100,26 +94,26 @@ def calculate_structure_function(  # noqa: D417, C901
 
     for key, value in inputs.items():
         if value is not None:
-            right_shift, down_shift = shift_array2d(
-                inputs[key], shift_down=down, shift_right=right, boundary=boundary
+            x_shift, y_shift = shift_array2d(
+                inputs[key], shift_x=shift_x, shift_y=shift_y, boundary=boundary
             )
 
             shifted_inputs.update(
                 {
-                    key + "_right_shift": right_shift,
-                    key + "_down_shift": down_shift,
+                    key + "_x_shift": x_shift,
+                    key + "_y_shift": y_shift,
                 }
             )
 
     inputs.update(shifted_inputs)
     SF_dict = {}
 
-    for direction in ["right", "down"]:
+    for direction in ["x", "y"]:
         if skip_velocity_sf is False:
             SF_dict["SF_velocity_" + direction] = np.nanmean(
-                (inputs["adv_e_" + direction + "_shift"] - adv_e)
+                (inputs["adv_e_" + direction + "_shift"] - adv_x)
                 * (inputs["u_" + direction + "_shift"] - u)
-                + (inputs["adv_n_" + direction + "_shift"] - adv_n)
+                + (inputs["adv_n_" + direction + "_shift"] - adv_y)
                 * (inputs["v_" + direction + "_shift"] - v)
             )
             if traditional_type is not None:
@@ -132,13 +126,13 @@ def calculate_structure_function(  # noqa: D417, C901
                         (inputs["u_" + direction + "_shift"] - u) ** 3
                     )
                 if any("LTT" in t for t in traditional_type):
-                    if direction == "right":
+                    if direction == "x":
                         SF_dict["SF_LTT_" + direction] = np.nanmean(
                             (inputs["u_" + direction + "_shift"] - u)
                             * (inputs["v_" + direction + "_shift"] - v) ** 2
                         )
 
-                    if direction == "down":
+                    if direction == "y":
                         SF_dict["SF_LTT_" + direction] = np.nanmean(
                             (inputs["v_" + direction + "_shift"] - v)
                             * (inputs["u_" + direction + "_shift"] - u) ** 2

--- a/oceans_sf/calculate_structure_function.py
+++ b/oceans_sf/calculate_structure_function.py
@@ -111,9 +111,9 @@ def calculate_structure_function(  # noqa: D417, C901
     for direction in ["x", "y"]:
         if skip_velocity_sf is False:
             SF_dict["SF_velocity_" + direction] = np.nanmean(
-                (inputs["adv_e_" + direction + "_shift"] - adv_x)
+                (inputs["adv_x_" + direction + "_shift"] - adv_x)
                 * (inputs["u_" + direction + "_shift"] - u)
-                + (inputs["adv_n_" + direction + "_shift"] - adv_y)
+                + (inputs["adv_y_" + direction + "_shift"] - adv_y)
                 * (inputs["v_" + direction + "_shift"] - v)
             )
             if traditional_type is not None:

--- a/oceans_sf/generate_structure_functions.py
+++ b/oceans_sf/generate_structure_functions.py
@@ -73,122 +73,81 @@ def generate_structure_functions(  # noqa: C901, D417
 
     """
     # Initialize variables as NoneType
-    SF_z = None
-    SF_m = None
-    SF_z_scalar = None
-    SF_m_scalar = None
-    adv_E = None
-    adv_N = None
+    SF_adv_x = None
+    SF_adv_y = None
+    SF_x_scalar = None
+    SF_y_scalar = None
+    adv_x = None
+    adv_y = None
     adv_scalar = None
-    SF_z_LL = None
-    SF_m_LL = None
-    SF_z_LLL = None
-    SF_m_LLL = None
-    SF_z_LTT = None
-    SF_m_LTT = None
-    SF_z_LSS = None
-    SF_m_LSS = None
+    SF_x_LL = None
+    SF_y_LL = None
+    SF_x_LLL = None
+    SF_y_LLL = None
+    SF_x_LTT = None
+    SF_y_LTT = None
+    SF_x_LSS = None
+    SF_y_LSS = None
 
     # Define a list of separation distances to iterate over.
     # Periodic is half the length since the calculation will wrap the data.
     if boundary == "periodic-all":
-        sep_z = range(1, int(len(x) / 2))
-        sep_m = range(1, int(len(y) / 2))
+        sep_x = range(1, int(len(x) / 2))
+        sep_y = range(1, int(len(y) / 2))
     elif boundary == "periodic-x":
-        sep_z = range(1, int(len(x) / 2))
-        sep_m = range(1, int(len(y) - 1))
+        sep_x = range(1, int(len(x) / 2))
+        sep_y = range(1, int(len(y) - 1))
     elif boundary == "periodic-y":
-        sep_z = range(1, int(len(x) - 1))
-        sep_m = range(1, int(len(y) / 2))
+        sep_x = range(1, int(len(x) - 1))
+        sep_y = range(1, int(len(y) / 2))
     elif boundary is None:
-        sep_z = range(1, int(len(x) - 1))
-        sep_m = range(1, int(len(y) - 1))
+        sep_x = range(1, int(len(x) - 1))
+        sep_y = range(1, int(len(y) - 1))
 
     # Initialize the separation distance arrays
-    xd = np.zeros(len(sep_z) + 1)
-    yd = np.zeros(len(sep_m) + 1)
+    xd = np.zeros(len(sep_x) + 1)
+    yd = np.zeros(len(sep_y) + 1)
 
     # Initialize the structure function arrays
     if skip_velocity_sf is False:
-        SF_z = np.zeros(len(sep_z) + 1)
-        SF_m = np.zeros(len(sep_m) + 1)
-        adv_E, adv_N = calculate_advection(u, v, x, y, dx, dy, grid_type)
+        SF_adv_x = np.zeros(len(sep_x) + 1)
+        SF_adv_y = np.zeros(len(sep_y) + 1)
+        adv_x, adv_y = calculate_advection(u, v, x, y, dx, dy, grid_type)
         if traditional_type is not None:
             if any("LL" in t for t in traditional_type):
-                SF_z_LL = np.zeros(len(sep_z) + 1)
-                SF_m_LL = np.zeros(len(sep_m) + 1)
+                SF_x_LL = np.zeros(len(sep_x) + 1)
+                SF_y_LL = np.zeros(len(sep_y) + 1)
             if any("LLL" in t for t in traditional_type):
-                SF_z_LLL = np.zeros(len(sep_z) + 1)
-                SF_m_LLL = np.zeros(len(sep_m) + 1)
+                SF_x_LLL = np.zeros(len(sep_x) + 1)
+                SF_y_LLL = np.zeros(len(sep_y) + 1)
             if any("LTT" in t for t in traditional_type):
-                SF_z_LTT = np.zeros(len(sep_z) + 1)
-                SF_m_LTT = np.zeros(len(sep_m) + 1)
+                SF_x_LTT = np.zeros(len(sep_x) + 1)
+                SF_y_LTT = np.zeros(len(sep_y) + 1)
 
     if scalar is not None:
-        SF_z_scalar = np.zeros(len(sep_z) + 1)
-        SF_m_scalar = np.zeros(len(sep_m) + 1)
+        SF_x_scalar = np.zeros(len(sep_x) + 1)
+        SF_y_scalar = np.zeros(len(sep_y) + 1)
         adv_scalar = calculate_advection(u, v, x, y, dx, dy, grid_type, scalar)
         if traditional_type is not None:
             if any("LSS" in t for t in traditional_type):
-                SF_z_LSS = np.zeros(len(sep_z) + 1)
-                SF_m_LSS = np.zeros(len(sep_m) + 1)
+                SF_x_LSS = np.zeros(len(sep_x) + 1)
+                SF_y_LSS = np.zeros(len(sep_y) + 1)
 
-    # Iterate over separations right and down
-    for down in sep_m:
-        right = 1
-        if boundary == "periodic-all" or boundary == "periodic-y":
-            yroll = shift_array1d(y, shift_by=down, boundary="Periodic")
-        else:
-            yroll = shift_array1d(y, shift_by=down, boundary=None)
-
-        SF_dicts = calculate_structure_function(
-            u,
-            v,
-            adv_E,
-            adv_N,
-            down,
-            right,
-            skip_velocity_sf,
-            scalar,
-            adv_scalar,
-            traditional_type,
-            boundary,
-        )
-
-        if skip_velocity_sf is False:
-            SF_m[down] = SF_dicts["SF_velocity_down"]
-            if traditional_type is not None:
-                if any("LL" in t for t in traditional_type):
-                    SF_m_LL[down] = SF_dicts["SF_LL_down"]
-                if any("LLL" in t for t in traditional_type):
-                    SF_m_LLL[down] = SF_dicts["SF_LLL_down"]
-                if any("LTT" in t for t in traditional_type):
-                    SF_m_LTT[down] = SF_dicts["SF_LTT_down"]
-        if scalar is not None:
-            SF_m_scalar[down] = SF_dicts["SF_scalar_down"]
-            if traditional_type is not None:
-                if any("LSS" in t for t in traditional_type):
-                    SF_m_LSS[down] = SF_dicts["SF_LSS_down"]
-
-        # Calculate separation distances in y
-        tmp, yd[down] = calculate_separation_distances(
-            x[right], y[down], x[right], yroll[down], grid_type
-        )
-
-    for right in sep_z:
-        down = 1
+    # Iterate over separations in x and y
+    for x_shift in sep_x:
+        y_shift = 1
         if boundary == "periodic-all" or boundary == "periodic-x":
-            xroll = shift_array1d(x, shift_by=right, boundary="Periodic")
+            xroll = shift_array1d(x, shift_by=x_shift, boundary="Periodic")
         else:
-            xroll = shift_array1d(x, shift_by=right, boundary=None)
+            xroll = shift_array1d(x, shift_by=x_shift, boundary=None)
 
         SF_dicts = calculate_structure_function(
             u,
             v,
-            adv_E,
-            adv_N,
-            down,
-            right,
+            adv_x,
+            adv_y,
+            x_shift,
+            y_shift,
             skip_velocity_sf,
             scalar,
             adv_scalar,
@@ -197,63 +156,106 @@ def generate_structure_functions(  # noqa: C901, D417
         )
 
         if skip_velocity_sf is False:
-            SF_z[right] = SF_dicts["SF_velocity_right"]
+            SF_adv_x[x_shift] = SF_dicts["SF_velocity_x"]
             if traditional_type is not None:
                 if any("LL" in t for t in traditional_type):
-                    SF_z_LL[right] = SF_dicts["SF_LL_right"]
+                    SF_x_LL[x_shift] = SF_dicts["SF_LL_x"]
                 if any("LLL" in t for t in traditional_type):
-                    SF_z_LLL[right] = SF_dicts["SF_LLL_right"]
+                    SF_x_LLL[x_shift] = SF_dicts["SF_LLL_x"]
                 if any("LTT" in t for t in traditional_type):
-                    SF_z_LTT[right] = SF_dicts["SF_LTT_right"]
+                    SF_x_LTT[x_shift] = SF_dicts["SF_LTT_x"]
         if scalar is not None:
-            SF_z_scalar[right] = SF_dicts["SF_scalar_right"]
+            SF_x_scalar[x_shift] = SF_dicts["SF_scalar_x"]
             if traditional_type is not None:
                 if any("LSS" in t for t in traditional_type):
-                    SF_z_LSS[right] = SF_dicts["SF_LSS_right"]
+                    SF_x_LSS[x_shift] = SF_dicts["SF_LSS_x"]
 
         # Calculate separation distances in x
-        xd[right], tmp = calculate_separation_distances(
-            x[right], y[down], xroll[right], y[down], grid_type
+        xd[x_shift], tmp = calculate_separation_distances(
+            x[x_shift], y[y_shift], xroll[x_shift], y[y_shift], grid_type
         )
+
+    for y_shift in sep_y:
+        x_shift = 1
+        if boundary == "periodic-all" or boundary == "periodic-y":
+            yroll = shift_array1d(y, shift_by=y_shift, boundary="Periodic")
+        else:
+            yroll = shift_array1d(y, shift_by=y_shift, boundary=None)
+
+        SF_dicts = calculate_structure_function(
+            u,
+            v,
+            adv_x,
+            adv_y,
+            x_shift,
+            y_shift,
+            skip_velocity_sf,
+            scalar,
+            adv_scalar,
+            traditional_type,
+            boundary,
+        )
+
+        if skip_velocity_sf is False:
+            SF_adv_y[y_shift] = SF_dicts["SF_velocity_y"]
+            if traditional_type is not None:
+                if any("LL" in t for t in traditional_type):
+                    SF_y_LL[y_shift] = SF_dicts["SF_LL_y"]
+                if any("LLL" in t for t in traditional_type):
+                    SF_y_LLL[y_shift] = SF_dicts["SF_LLL_y"]
+                if any("LTT" in t for t in traditional_type):
+                    SF_y_LTT[y_shift] = SF_dicts["SF_LTT_y"]
+        if scalar is not None:
+            SF_y_scalar[y_shift] = SF_dicts["SF_scalar_y"]
+            if traditional_type is not None:
+                if any("LSS" in t for t in traditional_type):
+                    SF_y_LSS[y_shift] = SF_dicts["SF_LSS_y"]
+
+        # Calculate separation distances in y
+        tmp, yd[y_shift] = calculate_separation_distances(
+            x[x_shift], y[y_shift], x[x_shift], yroll[y_shift], grid_type
+        )
+
+
 
     # Bin the data if the grid is uneven
     if even is False:
         if skip_velocity_sf is False:
-            xd_bin, SF_z = bin_data(xd, SF_z, nbins)
-            yd_bin, SF_m = bin_data(yd, SF_m, nbins)
+            xd_bin, SF_adv_x = bin_data(xd, SF_adv_x, nbins)
+            yd_bin, SF_adv_y = bin_data(yd, SF_adv_y, nbins)
             if traditional_type is not None:
                 if any("LL" in t for t in traditional_type):
-                    xd_bin, SF_z_LL = bin_data(xd, SF_z_LL, nbins)
-                    yd_bin, SF_m_LL = bin_data(yd, SF_m_LL, nbins)
+                    xd_bin, SF_x_LL = bin_data(xd, SF_x_LL, nbins)
+                    yd_bin, SF_y_LL = bin_data(yd, SF_y_LL, nbins)
                 if any("LLL" in t for t in traditional_type):
-                    xd_bin, SF_z_LLL = bin_data(xd, SF_z_LLL, nbins)
-                    yd_bin, SF_m_LLL = bin_data(yd, SF_m_LLL, nbins)
+                    xd_bin, SF_x_LLL = bin_data(xd, SF_x_LLL, nbins)
+                    yd_bin, SF_y_LLL = bin_data(yd, SF_y_LLL, nbins)
                 if any("LTT" in t for t in traditional_type):
-                    xd_bin, SF_z_LTT = bin_data(xd, SF_z_LTT, nbins)
-                    yd_bin, SF_m_LTT = bin_data(yd, SF_m_LTT, nbins)
+                    xd_bin, SF_x_LTT = bin_data(xd, SF_x_LTT, nbins)
+                    yd_bin, SF_y_LTT = bin_data(yd, SF_y_LTT, nbins)
         if scalar is not None:
-            xd_bin, SF_z_scalar = bin_data(xd, SF_z_scalar, nbins)
-            yd_bin, SF_m_scalar = bin_data(yd, SF_m_scalar, nbins)
+            xd_bin, SF_x_scalar = bin_data(xd, SF_x_scalar, nbins)
+            yd_bin, SF_y_scalar = bin_data(yd, SF_y_scalar, nbins)
             if traditional_type is not None:
                 if any("LSS" in t for t in traditional_type):
-                    xd_bin, SF_z_LSS = bin_data(xd, SF_z_LSS, nbins)
-                    yd_bin, SF_m_LSS = bin_data(yd, SF_m_LSS, nbins)
+                    xd_bin, SF_x_LSS = bin_data(xd, SF_x_LSS, nbins)
+                    yd_bin, SF_y_LSS = bin_data(yd, SF_y_LSS, nbins)
         xd = xd_bin
         yd = yd_bin
 
     data = {
-        "SF_advection_velocity_x": SF_z,
-        "SF_advection_velocity_y": SF_m,
-        "SF_advection_scalar_x": SF_z_scalar,
-        "SF_advection_scalar_y": SF_m_scalar,
-        "SF_LL_x": SF_z_LL,
-        "SF_LL_y": SF_m_LL,
-        "SF_LLL_x": SF_z_LLL,
-        "SF_LLL_y": SF_m_LLL,
-        "SF_LTT_x": SF_z_LTT,
-        "SF_LTT_y": SF_m_LTT,
-        "SF_LSS_x": SF_z_LSS,
-        "SF_LSS_y": SF_m_LSS,
+        "SF_advection_velocity_x": SF_adv_x,
+        "SF_advection_velocity_y": SF_adv_y,
+        "SF_advection_scalar_x": SF_x_scalar,
+        "SF_advection_scalar_y": SF_y_scalar,
+        "SF_LL_x": SF_x_LL,
+        "SF_LL_y": SF_y_LL,
+        "SF_LLL_x": SF_x_LLL,
+        "SF_LLL_y": SF_y_LLL,
+        "SF_LTT_x": SF_x_LTT,
+        "SF_LTT_y": SF_y_LTT,
+        "SF_LSS_x": SF_x_LSS,
+        "SF_LSS_y": SF_y_LSS,
         "x-diffs": xd,
         "y-diffs": yd,
     }

--- a/oceans_sf/generate_structure_functions.py
+++ b/oceans_sf/generate_structure_functions.py
@@ -29,7 +29,7 @@ def generate_structure_functions(  # noqa: C901, D417
     Full method for generating structure functions for 2D data, either advective or
     traditional structure functions. Supports velocity-based and scalar-based structure
     functions. Defaults to calculating the velocity-based advective structure functions
-    for the x (zonal) and y (meridional) directions.
+    for the x and y directions.
 
     Parameters
     ----------
@@ -69,7 +69,7 @@ def generate_structure_functions(  # noqa: C901, D417
     -------
         dict:
             Dictionary containing the requested structure functions and separation
-            distances for the x- and y-direction (zonal and meridional, respectively).
+            distances for the x- and y-direction.
 
     """
     # Initialize variables as NoneType
@@ -242,18 +242,18 @@ def generate_structure_functions(  # noqa: C901, D417
         yd = yd_bin
 
     data = {
-        "SF_advection_velocity_zonal": SF_z,
-        "SF_advection_velocity_meridional": SF_m,
-        "SF_advection_scalar_zonal": SF_z_scalar,
-        "SF_advection_scalar_meridional": SF_m_scalar,
-        "SF_LL_zonal": SF_z_LL,
-        "SF_LL_meridional": SF_m_LL,
-        "SF_LLL_zonal": SF_z_LLL,
-        "SF_LLL_meridional": SF_m_LLL,
-        "SF_LTT_zonal": SF_z_LTT,
-        "SF_LTT_meridional": SF_m_LTT,
-        "SF_LSS_zonal": SF_z_LSS,
-        "SF_LSS_meridional": SF_m_LSS,
+        "SF_advection_velocity_x": SF_z,
+        "SF_advection_velocity_y": SF_m,
+        "SF_advection_scalar_x": SF_z_scalar,
+        "SF_advection_scalar_y": SF_m_scalar,
+        "SF_LL_x": SF_z_LL,
+        "SF_LL_y": SF_m_LL,
+        "SF_LLL_x": SF_z_LLL,
+        "SF_LLL_y": SF_m_LLL,
+        "SF_LTT_x": SF_z_LTT,
+        "SF_LTT_y": SF_m_LTT,
+        "SF_LSS_x": SF_z_LSS,
+        "SF_LSS_y": SF_m_LSS,
         "x-diffs": xd,
         "y-diffs": yd,
     }

--- a/oceans_sf/generate_structure_functions.py
+++ b/oceans_sf/generate_structure_functions.py
@@ -216,8 +216,6 @@ def generate_structure_functions(  # noqa: C901, D417
             x[x_shift], y[y_shift], x[x_shift], yroll[y_shift], grid_type
         )
 
-
-
     # Bin the data if the grid is uneven
     if even is False:
         if skip_velocity_sf is False:

--- a/oceans_sf/shift_array2d.py
+++ b/oceans_sf/shift_array2d.py
@@ -2,22 +2,22 @@ import numpy as np
 
 
 def shift_array2d(  # noqa: D417
-    input_array, shift_right=1, shift_down=1, boundary="periodic-all"
+    input_array, shift_x=1, shift_y=1, boundary="periodic-all"
 ):
     """
-    Shifts 2D array right and down by the specified integer amounts and returns
+    Shifts 2D array in x and y by the specified integer amounts and returns
     the shifted arrays. Either wraps the array or shifts and pads with NaNs.
 
     Parameters
     ----------
         input_array: array_like
             2-dimensional array to be shifted.
-        shift_right: int, optional
-            Shift amount for rightward shift. For periodic data should be less than
+        shift_x: int, optional
+            Shift amount in x direction. For periodic data should be less than
             half the row length and less than the row length for other boundary
             conditions. Defaults to 1.
-        shift_down: int, optional
-            Shift amount for downward shift. For periodic data should be less than
+        shift_y: int, optional
+            Shift amount in y direction. For periodic data should be less than
             half the column length and less than the column length for other boundary
             conditions. Defaults to 1.
         boundary: str, optional
@@ -28,35 +28,35 @@ def shift_array2d(  # noqa: D417
 
     Returns
     -------
-        shifted_right_array
-            2D array shifted to the right by the specified integer amount
-        shifted_down_array
-            2D array shifted down by the specified integer amount
+        shifted_x_array
+            2D array shifted in x by the specified integer amount
+        shifted_y_array
+            2D array shifted in y by the specified integer amount
     """
-    shifted_right_array = np.full(np.shape(input_array), np.nan)
-    shifted_down_array = np.full(np.shape(input_array), np.nan)
+    shifted_x_array = np.full(np.shape(input_array), np.nan)
+    shifted_y_array = np.full(np.shape(input_array), np.nan)
 
     if boundary == "periodic-all":
-        shifted_right_array[:, :shift_right] = input_array[:, -shift_right:]
-        shifted_right_array[:, shift_right:] = input_array[:, :-shift_right]
+        shifted_x_array[:, :shift_x] = input_array[:, -shift_x:]
+        shifted_x_array[:, shift_x:] = input_array[:, :-shift_x]
 
-        shifted_down_array[:shift_down, :] = input_array[-shift_down:, :]
-        shifted_down_array[shift_down:, :] = input_array[:-shift_down, :]
+        shifted_y_array[:shift_y, :] = input_array[-shift_y:, :]
+        shifted_y_array[shift_y:, :] = input_array[:-shift_y, :]
 
     elif boundary == "periodic-x":
-        shifted_right_array[:, :shift_right] = input_array[:, -shift_right:]
-        shifted_right_array[:, shift_right:] = input_array[:, :-shift_right]
+        shifted_x_array[:, :shift_x] = input_array[:, -shift_x:]
+        shifted_x_array[:, shift_x:] = input_array[:, :-shift_x]
 
-        shifted_down_array[shift_down:, :] = input_array[:-shift_down, :]
+        shifted_y_array[shift_y:, :] = input_array[:-shift_y, :]
 
     elif boundary == "periodic-y":
-        shifted_right_array[:, shift_right:] = input_array[:, :-shift_right]
+        shifted_x_array[:, shift_x:] = input_array[:, :-shift_x]
 
-        shifted_down_array[:shift_down, :] = input_array[-shift_down:, :]
-        shifted_down_array[shift_down:, :] = input_array[:-shift_down, :]
+        shifted_y_array[:shift_y, :] = input_array[-shift_y:, :]
+        shifted_y_array[shift_y:, :] = input_array[:-shift_y, :]
 
     elif boundary is None:
-        shifted_right_array[:, shift_right:] = input_array[:, :-shift_right]
-        shifted_down_array[shift_down:, :] = input_array[:-shift_down, :]
+        shifted_x_array[:, shift_x:] = input_array[:, :-shift_x]
+        shifted_y_array[shift_y:, :] = input_array[:-shift_y, :]
 
-    return shifted_right_array, shifted_down_array
+    return shifted_x_array, shifted_y_array

--- a/tests/test_calculate_structure_function.py
+++ b/tests/test_calculate_structure_function.py
@@ -7,27 +7,27 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
 
 
 @pytest.mark.parametrize(
-    "u, v, adv_e, adv_n, down, right, skip_velocity_sf, scalar, "
+    "u, v, adv_x, adv_y, shift_x, shift_y, skip_velocity_sf, scalar, "
     "adv_scalar, traditional_type, boundary, expected_result",
     [
         # Test 1: velocity and scalar no traditional
         (
             np.array([[1, 2], [3, 4]]),  # u
             np.array([[1, -2], [-3, 4]]),  # v
-            np.array([[3, -2], [-3, 12]]),  # adv_e
-            np.array([[-7, -18], [33, 52]]),  # adv_n
-            1,  # down
-            1,  # right
+            np.array([[3, -2], [-3, 12]]),  # adv_x
+            np.array([[-7, -18], [33, 52]]),  # adv_y
+            1,  # x_shift
+            1,  # y_shift
             False,  # skip_velocity_sf
             np.array([[1, 2], [3, 4]]),  # scalar
             np.array([[3, -2], [-3, 12]]),  # adv_scalar
             None,  # traditional_type
             "periodic-all",  # boundary
             {
-                "SF_velocity_right": 88,
-                "SF_velocity_down": 138,
-                "SF_scalar_right": 5,
-                "SF_scalar_down": 8,
+                "SF_velocity_x": 88,
+                "SF_velocity_y": 138,
+                "SF_scalar_x": 5,
+                "SF_scalar_y": 8,
             },
             # expected_result
         ),
@@ -45,12 +45,12 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             ["LL"],
             "periodic-all",
             {
-                "SF_velocity_right": 88,
-                "SF_LL_right": 1,
-                "SF_scalar_right": 5,
-                "SF_velocity_down": 138,
-                "SF_LL_down": 4,
-                "SF_scalar_down": 8,
+                "SF_velocity_x": 88,
+                "SF_LL_x": 1,
+                "SF_scalar_x": 5,
+                "SF_velocity_y": 138,
+                "SF_LL_y": 4,
+                "SF_scalar_y": 8,
             },
         ),
         # Test 3: all but skip velocity and no traditional
@@ -67,8 +67,8 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             None,
             "periodic-all",
             {
-                "SF_scalar_right": 5,
-                "SF_scalar_down": 8,
+                "SF_scalar_x": 5,
+                "SF_scalar_y": 8,
             },
         ),
         # Test 4: velocities with no scalar or traditional
@@ -85,8 +85,8 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             None,
             "periodic-all",
             {
-                "SF_velocity_right": 88,
-                "SF_velocity_down": 138,
+                "SF_velocity_x": 88,
+                "SF_velocity_y": 138,
             },
         ),
         # Test 5: velocity and scalar no traditional non-periodic
@@ -103,10 +103,10 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             None,
             None,
             {
-                "SF_velocity_right": 88,
-                "SF_velocity_down": 138,
-                "SF_scalar_right": 5,
-                "SF_scalar_down": 8,
+                "SF_velocity_x": 88,
+                "SF_velocity_y": 138,
+                "SF_scalar_x": 5,
+                "SF_scalar_y": 8,
             },
         ),
         # Test 6: all non-periodic
@@ -123,12 +123,12 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             ["LL"],
             None,
             {
-                "SF_velocity_right": 88,
-                "SF_LL_right": 1,
-                "SF_scalar_right": 5,
-                "SF_velocity_down": 138,
-                "SF_LL_down": 4,
-                "SF_scalar_down": 8,
+                "SF_velocity_x": 88,
+                "SF_LL_x": 1,
+                "SF_scalar_x": 5,
+                "SF_velocity_y": 138,
+                "SF_LL_y": 4,
+                "SF_scalar_y": 8,
             },
         ),
         # Test 7: all but skip velocity and no traditional non-periodic
@@ -145,8 +145,8 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             None,
             None,
             {
-                "SF_scalar_right": 5,
-                "SF_scalar_down": 8,
+                "SF_scalar_x": 5,
+                "SF_scalar_y": 8,
             },
         ),
         # Test 8: velocities with no scalar or traditional non-periodic
@@ -163,8 +163,8 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
             None,
             None,
             {
-                "SF_velocity_right": 88,
-                "SF_velocity_down": 138,
+                "SF_velocity_x": 88,
+                "SF_velocity_y": 138,
             },
         ),
     ],
@@ -172,10 +172,10 @@ from oceans_sf.calculate_structure_function import calculate_structure_function
 def test_calculate_structure_function_parameterized(
     u,
     v,
-    adv_e,
-    adv_n,
-    down,
-    right,
+    adv_x,
+    adv_y,
+    shift_x,
+    shift_y,
     skip_velocity_sf,
     scalar,
     adv_scalar,
@@ -187,10 +187,10 @@ def test_calculate_structure_function_parameterized(
     output_dict = calculate_structure_function(
         u,
         v,
-        adv_e,
-        adv_n,
-        down,
-        right,
+        adv_x,
+        adv_y,
+        shift_x,
+        shift_y,
         skip_velocity_sf,
         scalar,
         adv_scalar,

--- a/tests/test_generate_structure_functions.py
+++ b/tests/test_generate_structure_functions.py
@@ -111,13 +111,9 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             10,  # nbins
             {
                 "SF_advection_velocity_x": np.array([0, 945, 1680, 2205, 2520]),
-                "SF_advection_velocity_y": np.array(
-                    [0, 94500, 168000, 220500, 252000]
-                ),
+                "SF_advection_velocity_y": np.array([0, 94500, 168000, 220500, 252000]),
                 "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
-                "SF_advection_scalar_y": np.array(
-                    [0, 170100, 302400, 396900, 453600]
-                ),
+                "SF_advection_scalar_y": np.array([0, 170100, 302400, 396900, 453600]),
                 "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
                 "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
                 "SF_LTT_x": np.array([0, 288, 384, 336, 192]),
@@ -255,13 +251,9 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             10,  # nbins
             {
                 "SF_advection_velocity_x": np.array([0, 945, 1680, 2205, 2520]),
-                "SF_advection_velocity_y": np.array(
-                    [0, 94500, 168000, 220500, 252000]
-                ),
+                "SF_advection_velocity_y": np.array([0, 94500, 168000, 220500, 252000]),
                 "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
-                "SF_advection_scalar_y": np.array(
-                    [0, 170100, 302400, 396900, 453600]
-                ),
+                "SF_advection_scalar_y": np.array([0, 170100, 302400, 396900, 453600]),
                 "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
                 "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
                 "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
@@ -389,13 +381,9 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                     [1237.5, 16087.5, 39600.0, 75487.5, 139837.5]
                 ),
                 "SF_LLL_x": np.array([0, -1, -8, -27]),
-                "SF_LLL_y": np.array(
-                    [-62.5, -2187.5, -8000.0, -21312.5, -53437.5]
-                ),
+                "SF_LLL_y": np.array([-62.5, -2187.5, -8000.0, -21312.5, -53437.5]),
                 "SF_LSS_x": np.array([0, -9, -72, -243]),
-                "SF_LSS_y": np.array(
-                    [-562.5, -19687.5, -72000, -191812.5, -480937.5]
-                ),
+                "SF_LSS_y": np.array([-562.5, -19687.5, -72000, -191812.5, -480937.5]),
                 "x-diffs": np.linspace(0, 3, 4),
                 "y-diffs": np.array([0.5, 2.5, 4, 5.5, 7.5]),
             },  # expected_dict
@@ -483,15 +471,11 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                 "SF_advection_velocity_x": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
                 ),
-                "SF_advection_velocity_y": np.array(
-                    [0, 94500, 168000, 220500, 252000]
-                ),
+                "SF_advection_velocity_y": np.array([0, 94500, 168000, 220500, 252000]),
                 "SF_advection_scalar_x": np.array(
                     [0, 189, 756, 1701, 3024, 4725, 6804, 9261, 12096]
                 ),
-                "SF_advection_scalar_y": np.array(
-                    [0, 170100, 302400, 396900, 453600]
-                ),
+                "SF_advection_scalar_y": np.array([0, 170100, 302400, 396900, 453600]),
                 "SF_LLL_x": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
                 "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
                 "SF_LSS_x": np.array(

--- a/tests/test_generate_structure_functions.py
+++ b/tests/test_generate_structure_functions.py
@@ -28,20 +28,20 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "uniform",  # grid_type
             10,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array(
+                "SF_advection_velocity_x": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
                 ),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_y": np.array(
                     [0, 10500, 42000, 94500, 168000, 262500, 378000, 514500, 672000]
                 ),
-                "SF_advection_scalar_zonal": np.array(
+                "SF_advection_scalar_x": np.array(
                     [0, 189, 756, 1701, 3024, 4725, 6804, 9261, 12096]
                 ),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_y": np.array(
                     [0, 18900, 75600, 170100, 302400, 472500, 680400, 926100, 1209600]
                 ),
-                "SF_LLL_zonal": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
-                "SF_LLL_meridional": np.array(
+                "SF_LLL_x": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
+                "SF_LLL_y": np.array(
                     [
                         0,
                         -1000,
@@ -54,10 +54,10 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                         -512000,
                     ]
                 ),
-                "SF_LTT_zonal": np.array(
+                "SF_LTT_x": np.array(
                     [0, -4, -32, -108, -256, -500, -864, -1372, -2048]
                 ),
-                "SF_LTT_meridional": np.array(
+                "SF_LTT_y": np.array(
                     [
                         0,
                         -2000,
@@ -70,10 +70,10 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                         -1024000,
                     ]
                 ),
-                "SF_LSS_zonal": np.array(
+                "SF_LSS_x": np.array(
                     [0, -9, -72, -243, -576, -1125, -1944, -3087, -4608]
                 ),
-                "SF_LSS_meridional": np.array(
+                "SF_LSS_y": np.array(
                     [
                         0,
                         -9000,
@@ -110,20 +110,20 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "uniform",  # grid_type
             10,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array([0, 945, 1680, 2205, 2520]),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_x": np.array([0, 945, 1680, 2205, 2520]),
+                "SF_advection_velocity_y": np.array(
                     [0, 94500, 168000, 220500, 252000]
                 ),
-                "SF_advection_scalar_zonal": np.array([0, 1701, 3024, 3969, 4536]),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
+                "SF_advection_scalar_y": np.array(
                     [0, 170100, 302400, 396900, 453600]
                 ),
-                "SF_LLL_zonal": np.array([0, 72, 96, 84, 48]),
-                "SF_LLL_meridional": np.array([0, 72000, 96000, 84000, 48000]),
-                "SF_LTT_zonal": np.array([0, 288, 384, 336, 192]),
-                "SF_LTT_meridional": np.array([0, 144000, 192000, 168000, 96000]),
-                "SF_LSS_zonal": np.array([0, 648, 864, 756, 432]),
-                "SF_LSS_meridional": np.array([0, 648000, 864000, 756000, 432000]),
+                "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
+                "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
+                "SF_LTT_x": np.array([0, 288, 384, 336, 192]),
+                "SF_LTT_y": np.array([0, 144000, 192000, 168000, 96000]),
+                "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
+                "SF_LSS_y": np.array([0, 648000, 864000, 756000, 432000]),
                 "x-diffs": np.linspace(0, 4, 5),
                 "y-diffs": np.linspace(0, 4, 5),
             },  # expected_dict
@@ -148,20 +148,20 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "latlon",  # grid_type
             10,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array(
+                "SF_advection_velocity_x": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
                 ),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_y": np.array(
                     [0, 10500, 42000, 94500, 168000, 262500, 378000, 514500, 672000]
                 ),
-                "SF_advection_scalar_zonal": np.array(
+                "SF_advection_scalar_x": np.array(
                     [0, 189, 756, 1701, 3024, 4725, 6804, 9261, 12096]
                 ),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_y": np.array(
                     [0, 18900, 75600, 170100, 302400, 472500, 680400, 926100, 1209600]
                 ),
-                "SF_LLL_zonal": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
-                "SF_LLL_meridional": np.array(
+                "SF_LLL_x": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
+                "SF_LLL_y": np.array(
                     [
                         0,
                         -1000,
@@ -174,10 +174,10 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                         -512000,
                     ]
                 ),
-                "SF_LTT_zonal": np.array(
+                "SF_LTT_x": np.array(
                     [0, -4, -32, -108, -256, -500, -864, -1372, -2048]
                 ),
-                "SF_LTT_meridional": np.array(
+                "SF_LTT_y": np.array(
                     [
                         0,
                         -2000,
@@ -190,10 +190,10 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                         -1024000,
                     ]
                 ),
-                "SF_LSS_zonal": np.array(
+                "SF_LSS_x": np.array(
                     [0, -9, -72, -243, -576, -1125, -1944, -3087, -4608]
                 ),
-                "SF_LSS_meridional": np.array(
+                "SF_LSS_y": np.array(
                     [
                         0,
                         -9000,
@@ -254,18 +254,18 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "latlon",  # grid_type
             10,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array([0, 945, 1680, 2205, 2520]),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_x": np.array([0, 945, 1680, 2205, 2520]),
+                "SF_advection_velocity_y": np.array(
                     [0, 94500, 168000, 220500, 252000]
                 ),
-                "SF_advection_scalar_zonal": np.array([0, 1701, 3024, 3969, 4536]),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
+                "SF_advection_scalar_y": np.array(
                     [0, 170100, 302400, 396900, 453600]
                 ),
-                "SF_LLL_zonal": np.array([0, 72, 96, 84, 48]),
-                "SF_LLL_meridional": np.array([0, 72000, 96000, 84000, 48000]),
-                "SF_LSS_zonal": np.array([0, 648, 864, 756, 432]),
-                "SF_LSS_meridional": np.array([0, 648000, 864000, 756000, 432000]),
+                "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
+                "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
+                "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
+                "SF_LSS_y": np.array([0, 648000, 864000, 756000, 432000]),
                 "x-diffs": np.array(
                     [
                         0.0,
@@ -306,14 +306,14 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "uniform",  # grid_type
             3,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array([175, 1750, 5215]),
-                "SF_advection_velocity_meridional": np.array([17500, 175000, 521500]),
-                "SF_advection_scalar_zonal": np.array([315, 3150, 9387]),
-                "SF_advection_scalar_meridional": np.array([31500, 315000, 938700]),
-                "SF_LLL_zonal": np.array([-3, -72, -357]),
-                "SF_LLL_meridional": np.array([-3000, -72000, -357000]),
-                "SF_LSS_zonal": np.array([-27, -648, -3213]),
-                "SF_LSS_meridional": np.array([-27000, -648000, -3213000]),
+                "SF_advection_velocity_x": np.array([175, 1750, 5215]),
+                "SF_advection_velocity_y": np.array([17500, 175000, 521500]),
+                "SF_advection_scalar_x": np.array([315, 3150, 9387]),
+                "SF_advection_scalar_y": np.array([31500, 315000, 938700]),
+                "SF_LLL_x": np.array([-3, -72, -357]),
+                "SF_LLL_y": np.array([-3000, -72000, -357000]),
+                "SF_LSS_x": np.array([-27, -648, -3213]),
+                "SF_LSS_y": np.array([-27000, -648000, -3213000]),
                 "x-diffs": np.array([1, 4, 7]),
                 "y-diffs": np.array([1, 4, 7]),
             },  # expected_dict
@@ -338,14 +338,14 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "latlon",  # grid_type
             3,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array([175, 1750, 5215]),
-                "SF_advection_velocity_meridional": np.array([17500, 175000, 521500]),
-                "SF_advection_scalar_zonal": np.array([315, 3150, 9387]),
-                "SF_advection_scalar_meridional": np.array([31500, 315000, 938700]),
-                "SF_LLL_zonal": np.array([-3, -72, -357]),
-                "SF_LLL_meridional": np.array([-3000, -72000, -357000]),
-                "SF_LSS_zonal": np.array([-27, -648, -3213]),
-                "SF_LSS_meridional": np.array(
+                "SF_advection_velocity_x": np.array([175, 1750, 5215]),
+                "SF_advection_velocity_y": np.array([17500, 175000, 521500]),
+                "SF_advection_scalar_x": np.array([315, 3150, 9387]),
+                "SF_advection_scalar_y": np.array([31500, 315000, 938700]),
+                "SF_LLL_x": np.array([-3, -72, -357]),
+                "SF_LLL_y": np.array([-3000, -72000, -357000]),
+                "SF_LSS_x": np.array([-27, -648, -3213]),
+                "SF_LSS_y": np.array(
                     [
                         -27000,
                         -648000,
@@ -380,20 +380,20 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "uniform",  # grid_type
             5,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array([0, 55, 220, 495]),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_x": np.array([0, 55, 220, 495]),
+                "SF_advection_velocity_y": np.array(
                     [687.5, 8937.5, 22000, 41937.5, 77687.5]
                 ),
-                "SF_advection_scalar_zonal": np.array([0, 99, 396, 891]),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_x": np.array([0, 99, 396, 891]),
+                "SF_advection_scalar_y": np.array(
                     [1237.5, 16087.5, 39600.0, 75487.5, 139837.5]
                 ),
-                "SF_LLL_zonal": np.array([0, -1, -8, -27]),
-                "SF_LLL_meridional": np.array(
+                "SF_LLL_x": np.array([0, -1, -8, -27]),
+                "SF_LLL_y": np.array(
                     [-62.5, -2187.5, -8000.0, -21312.5, -53437.5]
                 ),
-                "SF_LSS_zonal": np.array([0, -9, -72, -243]),
-                "SF_LSS_meridional": np.array(
+                "SF_LSS_x": np.array([0, -9, -72, -243]),
+                "SF_LSS_y": np.array(
                     [-562.5, -19687.5, -72000, -191812.5, -480937.5]
                 ),
                 "x-diffs": np.linspace(0, 3, 4),
@@ -420,16 +420,16 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "uniform",  # grid_type
             10,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array([0, 945, 1680, 2205, 2520]),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_x": np.array([0, 945, 1680, 2205, 2520]),
+                "SF_advection_velocity_y": np.array(
                     [0, 10500, 42000, 94500, 168000, 262500, 378000, 514500, 672000]
                 ),
-                "SF_advection_scalar_zonal": np.array([0, 1701, 3024, 3969, 4536]),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
+                "SF_advection_scalar_y": np.array(
                     [0, 18900, 75600, 170100, 302400, 472500, 680400, 926100, 1209600]
                 ),
-                "SF_LLL_zonal": np.array([0, 72, 96, 84, 48]),
-                "SF_LLL_meridional": np.array(
+                "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
+                "SF_LLL_y": np.array(
                     [
                         0,
                         -1000,
@@ -442,8 +442,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                         -512000,
                     ]
                 ),
-                "SF_LSS_zonal": np.array([0, 648, 864, 756, 432]),
-                "SF_LSS_meridional": np.array(
+                "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
+                "SF_LSS_y": np.array(
                     [
                         0,
                         -9000,
@@ -480,24 +480,24 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             "uniform",  # grid_type
             10,  # nbins
             {
-                "SF_advection_velocity_zonal": np.array(
+                "SF_advection_velocity_x": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
                 ),
-                "SF_advection_velocity_meridional": np.array(
+                "SF_advection_velocity_y": np.array(
                     [0, 94500, 168000, 220500, 252000]
                 ),
-                "SF_advection_scalar_zonal": np.array(
+                "SF_advection_scalar_x": np.array(
                     [0, 189, 756, 1701, 3024, 4725, 6804, 9261, 12096]
                 ),
-                "SF_advection_scalar_meridional": np.array(
+                "SF_advection_scalar_y": np.array(
                     [0, 170100, 302400, 396900, 453600]
                 ),
-                "SF_LLL_zonal": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
-                "SF_LLL_meridional": np.array([0, 72000, 96000, 84000, 48000]),
-                "SF_LSS_zonal": np.array(
+                "SF_LLL_x": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
+                "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
+                "SF_LSS_x": np.array(
                     [0, -9, -72, -243, -576, -1125, -1944, -3087, -4608]
                 ),
-                "SF_LSS_meridional": np.array([0, 648000, 864000, 756000, 432000]),
+                "SF_LSS_y": np.array([0, 648000, 864000, 756000, 432000]),
                 "x-diffs": np.linspace(0, 8, 9),
                 "y-diffs": np.linspace(0, 4, 5),
             },  # expected_dict


### PR DESCRIPTION
Small update to change doctsring and variable names from zonal/meridional to x/y for orientation of structure function calculations. Should be ready for merge already. 