### PR TITLE
Allow binning regardless of datatype

### DIFF
--- a/oceans_sf/generate_structure_functions.py
+++ b/oceans_sf/generate_structure_functions.py
@@ -20,9 +20,8 @@ def generate_structure_functions(  # noqa: C901, D417
     dx=None,
     dy=None,
     boundary="periodic-all",
-    even="True",
     grid_type="uniform",
-    nbins=10,
+    nbins=None,
 ):
     """
     TEST
@@ -58,12 +57,11 @@ def generate_structure_functions(  # noqa: C901, D417
         boundary: str, optional
             Boundary condition of the data. Accepted strings are "periodic-x",
             "periodic-y", and "periodic-all". Defaults to "periodic-all".
-        even: bool, optional
-            Flag indicating if the grid is evenly spaced. Defaults to True.
         grid_type:str, optional
             Type of grid, either "uniform" or "latlon". Defaults to "uniform".
         nbins: int, optional
-            Number of bins for binning the data. Defaults to 10.
+            Number of bins for binning the data. Defaults to None, i.e. does not bin 
+            data.
 
     Returns
     -------
@@ -216,8 +214,8 @@ def generate_structure_functions(  # noqa: C901, D417
             x[right], y[down], xroll[right], y[down], grid_type
         )
 
-    # Bin the data if the grid is uneven
-    if even is False:
+    # Bin the data if requested
+    if nbins is not None:
         if skip_velocity_sf is False:
             xd_bin, SF_z = bin_data(xd, SF_z, nbins)
             yd_bin, SF_m = bin_data(yd, SF_m, nbins)

--- a/oceans_sf/generate_structure_functions.py
+++ b/oceans_sf/generate_structure_functions.py
@@ -24,7 +24,6 @@ def generate_structure_functions(  # noqa: C901, D417
     nbins=None,
 ):
     """
-    TEST
     Full method for generating structure functions for 2D data, either advective or
     traditional structure functions. Supports velocity-based and scalar-based structure
     functions. Defaults to calculating the velocity-based advective structure functions

--- a/oceans_sf/generate_structure_functions.py
+++ b/oceans_sf/generate_structure_functions.py
@@ -59,7 +59,7 @@ def generate_structure_functions(  # noqa: C901, D417
         grid_type:str, optional
             Type of grid, either "uniform" or "latlon". Defaults to "uniform".
         nbins: int, optional
-            Number of bins for binning the data. Defaults to None, i.e. does not bin 
+            Number of bins for binning the data. Defaults to None, i.e. does not bin
             data.
 
     Returns

--- a/tests/test_generate_structure_functions.py
+++ b/tests/test_generate_structure_functions.py
@@ -5,7 +5,7 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
 
 
 @pytest.mark.parametrize(
-    "u, v, x, y, skip_velocity_sf, scalar, traditional_type, dx, dy, boundary, even, "
+    "u, v, x, y, skip_velocity_sf, scalar, traditional_type, dx, dy, boundary, "
     "grid_type, nbins, expected_dict",
     [
         # Test 1: all with no boundary and uniform grid
@@ -24,9 +24,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             None,  # dx
             None,  # dy
             None,  # boundary
-            True,  # even
             "uniform",  # grid_type
-            10,  # nbins
+            None,  # nbins
             {
                 "SF_advection_velocity_zonal": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
@@ -106,9 +105,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             None,  # dx
             None,  # dy
             "periodic-all",  # boundary
-            True,  # even
             "uniform",  # grid_type
-            10,  # nbins
+            None,  # nbins
             {
                 "SF_advection_velocity_zonal": np.array([0, 945, 1680, 2205, 2520]),
                 "SF_advection_velocity_meridional": np.array(
@@ -144,9 +142,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             np.ones(10),  # dx
             np.ones(10),  # dy
             None,  # boundary
-            True,  # even
             "latlon",  # grid_type
-            10,  # nbins
+            None,  # nbins
             {
                 "SF_advection_velocity_zonal": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
@@ -250,9 +247,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             np.ones(10),  # dx
             np.ones(10),  # dy
             "periodic-all",  # boundary
-            True,  # even
             "latlon",  # grid_type
-            10,  # nbins
+            None,  # nbins
             {
                 "SF_advection_velocity_zonal": np.array([0, 945, 1680, 2205, 2520]),
                 "SF_advection_velocity_meridional": np.array(
@@ -302,7 +298,6 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             None,  # dx
             None,  # dy
             None,  # boundary
-            False,  # even
             "uniform",  # grid_type
             3,  # nbins
             {
@@ -334,7 +329,6 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             np.ones(10),  # dx
             np.ones(10),  # dy
             None,  # boundary
-            False,  # even
             "latlon",  # grid_type
             3,  # nbins
             {
@@ -360,7 +354,7 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
                 ),
             },  # expected_dict
         ),
-        # Test 7: all with no boundary and uneven x vs y
+        # Test 7: all with no boundary and 5 bins
         (
             np.array(
                 [[i + 1 for i in range(j * 5, (j + 1) * 5)] for j in range(10)]
@@ -376,7 +370,6 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             None,  # dx
             None,  # dy
             None,  # boundary
-            False,  # even
             "uniform",  # grid_type
             5,  # nbins
             {
@@ -416,9 +409,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             None,  # dx
             None,  # dy
             "periodic-x",  # boundary
-            True,  # even
             "uniform",  # grid_type
-            10,  # nbins
+            None,  # nbins
             {
                 "SF_advection_velocity_zonal": np.array([0, 945, 1680, 2205, 2520]),
                 "SF_advection_velocity_meridional": np.array(
@@ -476,9 +468,8 @@ from oceans_sf.generate_structure_functions import generate_structure_functions
             None,  # dx
             None,  # dy
             "periodic-y",  # boundary
-            True,  # even
             "uniform",  # grid_type
-            10,  # nbins
+            None,  # nbins
             {
                 "SF_advection_velocity_zonal": np.array(
                     [0, 105, 420, 945, 1680, 2625, 3780, 5145, 6720]
@@ -515,7 +506,6 @@ def test_generate_structure_functions_parameterized(
     dx,
     dy,
     boundary,
-    even,
     grid_type,
     nbins,
     expected_dict,
@@ -532,7 +522,6 @@ def test_generate_structure_functions_parameterized(
         dx,
         dy,
         boundary,
-        even,
         grid_type,
         nbins,
     )


### PR DESCRIPTION
User can bin the data by setting `nbins=int`. Previous version required `even=True` and `nbins=int`, so `even` flag is removed. 

Binning occurs in `bin_data.py` with [pandas.DataFrame.groupby](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.groupby.html). This may be changed if necessary (i.e. allowing user-specified bin centers).